### PR TITLE
Topic modeling over source code identifiers

### DIFF
--- a/_publications/markovtsev2017topic.markdown
+++ b/_publications/markovtsev2017topic.markdown
@@ -5,6 +5,10 @@ authors: V. Markovtsev, E. Kant
 conference: ArXiV 1704.00135
 year: 2017
 bibkey: markovtsev2017topic
+additional_links:
+   - {name: "ArXiV", url: "https://arxiv.org/abs/1704.00135"}
+   - {name: "website", url: "https://blog.sourced.tech/post/github_topic_modeling"}
+   - {name: "code", url: "https://github.com/src-d/ast2vec/blob/master/topic_modeling.md"}
 ---
  Programming languages themselves have a limited number of reserved keywords and character based tokens that
 define the language specification. However, programmers have a rich use of natural language within their code

--- a/_publications/markovtsev2017topic.markdown
+++ b/_publications/markovtsev2017topic.markdown
@@ -1,0 +1,20 @@
+---
+layout: publication
+title: "Topic modeling of public repositories at scale using names in source code"
+authors: V. Markovtsev, E. Kant
+conference: ArXiV 1704.00135
+year: 2017
+bibkey: markovtsev2017topic
+---
+ Programming languages themselves have a limited number of reserved keywords and character based tokens that
+define the language specification. However, programmers have a rich use of natural language within their code
+through comments, text literals and naming entities. The programmer defined names that can be found in source
+code are a rich source of information to build a high level understanding of the project. The goal of this paper
+is to apply topic modeling to names used in over 13.6 million repositories and perceive the inferred topics.
+One of the problems in such a study is the occurrence of duplicate repositories not officially marked as forks (obscure forks).
+We show how to address it using the same identifiers which are extracted for topic modeling.
+
+We open with a discussion on naming in source code, we then elaborate on our approach to remove exact duplicate
+and fuzzy duplicate repositories using Locality Sensitive Hashing on the bag-of-words model and then discuss our work
+on topic modeling; and finally present the results from our data analysis together with open-access to the source code,
+tools and datasets.


### PR DESCRIPTION
Do you guys think it might be worth including https://arxiv.org/abs/1704.00135 ?

I know that you intentionally focus on things beyond BoW and TM models, but

 - it's a large-scale research over 13.6m source code repositories
 - uses regularized Topic Models
 - applies TM to the whole repositories
 - discuss repository duplicate detection
 - includes number of public datasets