### PR TITLE
Fix homepage link to Taxonomy page.

### DIFF
--- a/index.md
+++ b/index.md
@@ -23,7 +23,7 @@ and programming language communities.
 
 This site is an experiment: a living literature review that allows
 you explore the navigate the literature in this area, by
-following a [taxonomy](\taxnomomy)
+following a [taxonomy]({% link base-taxonomy/index.md %})
 based on the underlying design principles of each model.
 
 The full survey is available [as a research paper](https://arxiv.org/abs/1709.06182).


### PR DESCRIPTION
I fixed the broken link to the taxonomy page on the home page. I used Jekyll's [link tag](https://jekyllrb.com/docs/templates/#links) tag to *hopefully* make future changes more maintainable.