### PR TITLE
Add 8 papers about code search from SE/AI conferences

### DIFF
--- a/_publications/haldar2020a.markdown
+++ b/_publications/haldar2020a.markdown
@@ -1,0 +1,13 @@
+---
+layout: publication
+title: "A Multi-Perspective Architecture for Semantic Code Search"
+authors: Rajarshi Haldar, Lingfei Wu, Jinjun Xiong, Julia Hockenmaier
+conference: ACL
+year: 2020
+bibkey: haldar2020a
+additional_links:
+  - { name: "ArXiV", url: "https://arxiv.org/abs/2005.06980" }
+tags: ["search"]
+---
+
+The ability to match pieces of code to their corresponding natural language descriptions and vice versa is fundamental for natural language search interfaces to software repositories. In this paper, we propose a novel multi-perspective cross-lingual neural framework for code--text matching, inspired in part by a previous model for monolingual text-to-text matching, to capture both global and local similarities. Our experiments on the CoNaLa dataset show that our proposed model yields better performance on this cross-lingual text-to-code matching task than previous approaches that map code and text to a single joint embedding space.

--- a/_publications/li2020learning.markdown
+++ b/_publications/li2020learning.markdown
@@ -1,0 +1,13 @@
+---
+layout: publication
+title: "Learning Code-Query Interaction for Enhancing Code Searches"
+authors: Wei Li, Haozhe Qin, Shuhan Yan, Beijun Shen, Yuting Chen
+conference: ICSME
+year: 2020
+bibkey: li2020learning
+additional_links:
+  - { name: "IEEE", url: "https://ieeexplore.ieee.org/document/9240627" }
+tags: ["search"]
+---
+
+Code search plays an important role in software development and maintenance. In recent years, deep learning (DL) has achieved a great success in this domain-several DL-based code search methods, such as DeepCS and UNIF, have been proposed for exploring deep, semantic correlations between code and queries; each method usually embeds source code and natural language queries into real vectors followed by computing their vector distances representing their semantic correlations. Meanwhile, deep learning-based code search still suffers from three main problems, i.e., the OOV (Out of Vocabulary) problem, the independent similarity matching problem, and the small training dataset problem. To tackle the above problems, we propose CQIL, a novel, deep learning-based code search method. CQIL learns code-query interactions and uses a CNN (Convolutional Neural Network) to compute semantic correlations between queries and code snippets. In particular, CQIL employs a hybrid representation to model code-query correlations, which solves the OOV problem. CQIL also deeply learns the code-query interaction for enhancing code searches, which solves the independent similarity matching and the small training dataset problems. We evaluate CQIL on two datasets (CODEnn and CosBench). The evaluation results show the strengths of CQIL-it achieves the MAP@1 values, 0.694 and 0.574, on CODEnn and CosBench, respectively. In particular, it outperforms DeepCS and UNIF, two state-of-the-art code search methods, by 13.6% and 18.1% in MRR, respectively, when the training dataset is insufficient.

--- a/_publications/ling2020adaptive.markdown
+++ b/_publications/ling2020adaptive.markdown
@@ -1,0 +1,13 @@
+---
+layout: publication
+title: "Adaptive Deep Code Search"
+authors: Chunyang Ling, Zeqi Lin, Yanzhen Zou, Bing Xie
+conference: ICPC
+year: 2020
+bibkey: ling2020adaptive
+additional_links:
+  - { name: "ACM", url: "https://dl.acm.org/doi/abs/10.1145/3387904.3389278" }
+tags: ["search"]
+---
+
+Searching code in a large-scale codebase using natural language queries is a common practice during software development. Deep learning-based code search methods demonstrate superior performance if models are trained with large amount of text-code pairs. However, few deep code search models can be easily transferred from one codebase to another. It can be very costly to prepare training data for a new codebase and re-train an appropriate deep learning model. In this paper, we propose AdaCS, an adaptive deep code search method that can be trained once and transferred to new codebases. AdaCS decomposes the learning process into embedding domain-specific words and matching general syntactic patterns. Firstly, an unsupervised word embedding technique is used to construct a matching matrix to represent the lexical similarities. Then, a recurrent neural network is used to capture latent syntactic patterns from these matching matrices in a supervised way. As the supervised task learns general syntactic patterns that exist across domains, AdaCS is transferable to new codebases. Experimental results show that: when extended to new software projects never seen in the training data, AdaCS is more robust and significantly outperforms state-of-the-art deep code search methods.

--- a/_publications/ling2020deep.markdown
+++ b/_publications/ling2020deep.markdown
@@ -1,0 +1,13 @@
+---
+layout: publication
+title: "Deep Graph Matching and Searching for Semantic Code Retrieval"
+authors: Xiang Ling, Lingfei Wu, Saizhuo Wang, Gaoning Pan, Tengfei Ma, Fangli Xu, Alex X. Liu, Chunming Wu, Shouling Ji
+conference: TKDD
+year: 2020
+bibkey: ling2020deep
+additional_links:
+  - { name: "ArXiV", url: "https://arxiv.org/abs/2010.12908" }
+tags: ["search", "GNN"]
+---
+
+Code retrieval is to find the code snippet from a large corpus of source code repositories that highly matches the query of natural language description. Recent work mainly uses natural language processing techniques to process both query texts (i.e., human natural language) and code snippets (i.e., machine programming language), however neglecting the deep structured features of query texts and source codes, both of which contain rich semantic information. In this paper, we propose an end-to-end deep graph matching and searching (DGMS) model based on graph neural networks for the task of semantic code retrieval. To this end, we first represent both natural language query texts and programming language code snippets with the unified graph-structured data, and then use the proposed graph matching and searching model to retrieve the best matching code snippet. In particular, DGMS not only captures more structural information for individual query texts or code snippets but also learns the fine-grained similarity between them by cross-attention based semantic matching operations. We evaluate the proposed DGMS model on two public code retrieval datasets with two representative programming languages (i.e., Java and Python). Experiment results demonstrate that DGMS significantly outperforms state-of-the-art baseline models by a large margin on both datasets. Moreover, our extensive ablation studies systematically investigate and illustrate the impact of each part of DGMS.

--- a/_publications/shuai2020improving.markdown
+++ b/_publications/shuai2020improving.markdown
@@ -1,0 +1,15 @@
+---
+layout: publication
+title: "Improving Code Search with Co-Attentive Representation Learning"
+authors: Jianhang Shuai, Ling Xu, Chao Liu, Meng Yan, Xin Xia, Yan Lei
+conference: ICPC
+year: 2020
+bibkey: shuai2020improving
+additional_links:
+  - { name: "ACM", url: "https://dl.acm.org/doi/abs/10.1145/3387904.3389269" }
+tags: ["search"]
+---
+
+Searching and reusing existing code from a large-scale codebase, e.g, GitHub, can help developers complete a programming task efficiently. Recently, Gu et al. proposed a deep learning-based model (i.e., DeepCS), which significantly outperformed prior models. The DeepCS embedded codebase and natural language queries into vectors by two LSTM (long and short-term memory) models separately, and returned developers the code with higher similarity to a code search query. However, such embedding method learned two isolated representations for code and query but ignored their internal semantic correlations. As a result, the learned isolated representations of code and query may limit the effectiveness of code search.
+
+To address the aforementioned issue, we propose a co-attentive representation learning model, i.e., Co-Attentive Representation Learning Code Search-CNN (CARLCS-CNN). CARLCS-CNN learns interdependent representations for the embedded code and query with a co-attention mechanism. Generally, such mechanism learns a correlation matrix between embedded code and query, and co-attends their semantic relationship via row/column-wise max-pooling. In this way, the semantic correlation between code and query can directly affect their individual representations. We evaluate the effectiveness of CARLCS-CNN on Gu et al.'s dataset with 10k queries. Experimental results show that the proposed CARLCS-CNN model significantly outperforms DeepCS by 26.72% in terms of MRR (mean reciprocal rank). Additionally, CARLCS-CNN is five times faster than DeepCS in model training and four times in testing.

--- a/_publications/yan2020are.markdown
+++ b/_publications/yan2020are.markdown
@@ -1,0 +1,13 @@
+---
+layout: publication
+title: "Are the Code Snippets What We Are Searching for? A Benchmark and an Empirical Study on Code Search with Natural-Language Queries"
+authors: Shuhan Yan, Hang Yu, Yuting Chen, Beijun Shen, Lingxiao Jiang
+conference: SANER
+year: 2020
+bibkey: yan2020are
+additional_links:
+  - { name: "IEEE", url: "https://ieeexplore.ieee.org/document/9054840" }
+tags: ["search"]
+---
+
+Code search methods, especially those that allow programmers to raise queries in a natural language, plays an important role in software development. It helps to improve programmers' productivity by returning sample code snippets from the Internet and/or source-code repositories for their natural-language queries. Meanwhile, there are many code search methods in the literature that support natural-language queries. Difficulties exist in recognizing the strengths and weaknesses of each method and choosing the right one for different usage scenarios, because (1) the implementations of those methods and the datasets for evaluating them are usually not publicly available, and (2) some methods leverage different training datasets or auxiliary data sources and thus their effectiveness cannot be fairly measured and may be negatively affected in practical uses. To build a common ground for measuring code search methods, this paper builds CosBench, a dataset that consists of 1000 projects, 52 code-independent natural-language queries with ground truths, and a set of scripts for calculating four metrics on code research results. We have evaluated four IR (Information Retrieval)-based and two DL (Deep Learning)-based code search methods on CosBench. The empirical evaluation results clearly show the usefulness of the CosBench dataset and various strengths of each code search method. We found that DL-based methods are more suitable for queries on reusing code, and IR-based ones for queries on resolving bugs and learning API uses.

--- a/_publications/ye2020leveraging.markdown
+++ b/_publications/ye2020leveraging.markdown
@@ -1,0 +1,13 @@
+---
+layout: publication
+title: "Leveraging Code Generation to Improve Code Retrieval and Summarization via Dual Learning"
+authors: Wei Ye, Rui Xie, Jinglei Zhang, Tianxiang Hu, Xiaoyin Wang, Shikun Zhang
+conference: WWW
+year: 2020
+bibkey: ye2020leveraging
+additional_links:
+  - { name: "ArXiV", url: "https://arxiv.org/abs/2002.10198" }
+tags: ["search", "summarization"]
+---
+
+Code summarization generates brief natural language description given a source code snippet, while code retrieval fetches relevant source code given a natural language query. Since both tasks aim to model the association between natural language and programming language, recent studies have combined these two tasks to improve their performance. However, researchers have yet been able to effectively leverage the intrinsic connection between the two tasks as they train these tasks in a separate or pipeline manner, which means their performance can not be well balanced. In this paper, we propose a novel end-to-end model for the two tasks by introducing an additional code generation task. More specifically, we explicitly exploit the probabilistic correlation between code summarization and code generation with dual learning, and utilize the two encoders for code summarization and code generation to train the code retrieval task via multi-task learning. We have carried out extensive experiments on an existing dataset of SQL and Python, and results show that our model can significantly improve the results of the code retrieval task over the-state-of-art models, as well as achieve competitive performance in terms of BLEU score for the code summarization task.

--- a/_publications/zhu2020ocor.markdown
+++ b/_publications/zhu2020ocor.markdown
@@ -1,0 +1,14 @@
+---
+layout: publication
+title: "OCoR: An Overlapping-Aware Code Retriever"
+authors: Qihao Zhu, Zeyu Sun, Xiran Liang, Yingfei Xiong, Lu Zhang
+conference: ASE
+year: 2020
+bibkey: zhu2020ocor
+additional_links:
+  - { name: "ArXiV", url: "https://arxiv.org/abs/2008.05201" }
+tags: ["search"]
+---
+
+Code retrieval helps developers reuse the code snippet in the open-source projects. Given a natural language description, code retrieval aims to search for the most relevant code among a set of code. Existing state-of-the-art approaches apply neural networks to code retrieval. However, these approaches still fail to capture an important feature: overlaps. The overlaps between different names used by different people indicate that two different names may be potentially related (e.g., "message" and "msg"), and the overlaps between identifiers in code and words in natural language descriptions indicate that the code snippet and the description may potentially be related. To address these problems, we propose a novel neural architecture named OCoR, where we introduce two specifically-designed components to capture overlaps: the first embeds identifiers by character to capture the overlaps between identifiers, and the second introduces a novel overlap matrix to represent the degrees of overlaps between each natural language word and each identifier.
+The evaluation was conducted on two established datasets. The experimental results show that OCoR significantly outperforms the existing state-of-the-art approaches and achieves 13.1% to 22.3% improvements. Moreover, we also conducted several in-depth experiments to help understand the performance of different components in OCoR.


### PR DESCRIPTION
Add 8 papers about code search from these conferences: ASE, ACL, ICPC, WWW, TKDD, ICSME, SANER.
- Leveraging Code Generation to Improve Code Retrieval and Summarization via Dual Learning
- A Multi-Perspective Architecture for Semantic Code Search
- Adaptive Deep Code Search
- Improving Code Search with Co-Attentive Representation Learning
- Are the Code Snippets What We Are Searching for? A Benchmark and an Empirical Study on Code Search with Natural-Language Queries
- Learning Code-Query Interaction for Enhancing Code Searches
- OCoR: An Overlapping-Aware Code Retriever
- Deep Graph Matching and Searching for Semantic Code Retrieval                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                