### PR TITLE
Added DreamCoder papers: ellis2021dreamcoder; wong2021leveraging;

### DIFF
--- a/_publications/ellis2021dreamcoder.markdown
+++ b/_publications/ellis2021dreamcoder.markdown
@@ -1,0 +1,14 @@
+---
+layout: publication
+title: "DreamCoder: bootstrapping inductive program synthesis with wake-sleep library learning"
+authors: Kevin Ellis, Catherine Wong, Maxwell Nye, Mathias Sable-Meyer, Luc Cary, Lucas Morales, Luke Hewitt, Armando Solar-Lezama, Joshua B. Tenenbaum
+conference: 42nd ACM SIGPLAN International Conference on Programming Language Design and Implementation (PLDI 2021)
+year: 2021
+bibkey: ellis2021dreamcoder
+additional_links:
+   - {name: "ArXiV", url: "https://arxiv.org/abs/2006.08381"}
+   - {name: "Paper", url: "https://dl.acm.org/doi/10.1145/3453483.3454080"}
+   - {name: "Code", url: "https://github.com/ellisk42/ec"}
+tags: ["synthesis", "search"]
+---
+We present a system for inductive program synthesis called DreamCoder, which inputs a corpus of synthesis problems each specified by one or a few examples, and automatically derives a library of program components and a neural search policy that can be used to efficiently solve other similar synthesis problems. The library and search policy bootstrap each other iteratively through a variant of "wake-sleep" approximate Bayesian learning. A new refactoring algorithm based on E-graph matching identifies common sub-components across synthesized programs, building a progressively deepening library of abstractions capturing the structure of the input domain. We evaluate on eight domains including classic program synthesis areas and AI tasks such as planning, inverse graphics, and equation discovery. We show that jointly learning the library and neural search policy leads to solving more problems, and solving them more quickly.

--- a/_publications/wong2021leveraging.markdown
+++ b/_publications/wong2021leveraging.markdown
@@ -1,0 +1,13 @@
+---
+layout: publication
+title: "Leveraging Language to Learn Program Abstractions and Search Heuristics"
+authors: Catherine Wong, Kevin Ellis, Joshua B. Tenenbaum, Jacob Andreas
+conference: Thirty-eighth International Conference on Machine Learning (ICML 2021)
+year: 2021
+bibkey: wong2021leveraging
+additional_links:
+   - {name: "ArXiV", url: "https://arxiv.org/abs/2106.11053"}
+   - {name: "Poster", url: "https://icml.cc/Conferences/2021/ScheduleMultitrack?event=10372"}
+tags: ["synthesis", "search"]
+---
+Inductive program synthesis, or inferring programs from examples of desired behavior, offers a general paradigm for building interpretable, robust, and generalizable machine learning systems. Effective program synthesis depends on two key ingredients: a strong library of functions from which to build programs, and an efficient search strategy for finding programs that solve a given task. We introduce LAPS (Language for Abstraction and Program Search), a technique for using natural language annotations to guide joint learning of libraries and neurally-guided search models for synthesis. When integrated into a state-of-the-art library learning system (DreamCoder), LAPS produces higher-quality libraries and improves search efficiency and generalization on three domains -- string editing, image composition, and abstract reasoning about scenes -- even when no natural language hints are available at test time.


### PR DESCRIPTION
Added the DreamCoder papers:

1. [DreamCoder: Growing generalizable, interpretable knowledge with wake-sleep Bayesian program learning](https://arxiv.org/pdf/2006.08381.pdf) - PLDI 2021
2. [Leveraging Language to Learn Program Abstractions and Search Heuristics](https://arxiv.org/pdf/2106.11053.pdf) - ICML 2021

The papers fall under the existing tags of  `["synthesis", "search"]`, and have been tagged accordingly.