### PR TITLE
TSNE vis: update the model & embeddings

### DIFF
--- a/etc/compute_embeddings.py
+++ b/etc/compute_embeddings.py
@@ -3,6 +3,7 @@ import json
 
 import numpy as np
 import torch
+import torch.nn.functional as F
 import sklearn.manifold
 import transformers
 
@@ -13,13 +14,20 @@ def parse_arguments():
     parser.add_argument("json", default=False, help="the path the json containing all papers.")
     parser.add_argument("outpath", default=False, help="the target path of the visualizations papers.")
     parser.add_argument("--seed", default=0, help="The seed for TSNE.", type=int)
+    parser.add_argument("--model", default='sentence-transformers/all-MiniLM-L6-v2', help="Name of the HF model")
+
     return parser.parse_args()
+
+def mean_pooling(token_embeddings, attention_mask):
+    """ Mean Pooling, takes attention mask into account for correct averaging"""
+    input_mask_expanded = attention_mask.unsqueeze(-1).expand(token_embeddings.size()).float()
+    return torch.sum(token_embeddings * input_mask_expanded, 1) / torch.clamp(input_mask_expanded.sum(1), min=1e-9)
 
 
 if __name__ == "__main__":
     args = parse_arguments()
-    tokenizer = transformers.AutoTokenizer.from_pretrained("deepset/sentence_bert")
-    model = transformers.AutoModel.from_pretrained("deepset/sentence_bert")
+    tokenizer = transformers.AutoTokenizer.from_pretrained(args.model)
+    model = transformers.AutoModel.from_pretrained(args.model)
     model.eval()
 
     with open(args.json) as f:
@@ -27,16 +35,19 @@ if __name__ == "__main__":
 
     print(f"Num papers: {len(data)}")
 
-    all_embeddings = []
+    corpus = []
     for paper_info in data:
-        with torch.no_grad():
-            token_ids = torch.tensor([tokenizer.encode(paper_info["abstract"])][:512])
-            hidden_states, _ = model(token_ids)[-2:]
-            all_embeddings.append(hidden_states.mean(0).mean(0).numpy())
+        corpus.append(tokenizer.sep_token.join([paper_info['title'], paper_info['abstract']]))
+
+    encoded_corpus = tokenizer(corpus, padding=True, truncation=True, return_tensors='pt')
+    with torch.no_grad():
+        hidden_states = model(**encoded_corpus).last_hidden_state
+
+    corpus_embeddings = mean_pooling(hidden_states, encoded_corpus['attention_mask'])
+    corpus_embeddings = F.normalize(corpus_embeddings, p=2, dim=1)
 
     np.random.seed(args.seed)
-    all_embeddings = np.array(all_embeddings)
-    out = sklearn.manifold.TSNE(n_components=2, metric="cosine").fit_transform(all_embeddings)
+    out = sklearn.manifold.TSNE(n_components=2, metric="cosine").fit_transform(corpus_embeddings)
 
     for i, paper_info in enumerate(data):
         paper_info['tsne_embedding'] = out[i].tolist()


### PR DESCRIPTION
Some improvements in visualisation relevant to #62.

It's using a ['all-MiniLM-L6-v2' model](https://www.sbert.net/docs/pretrained_models.html) (87Mb instead of 418Mb, the same 512 context size) that is faster & seems to provide better visualisation.

**Before**: the previous model 
<img width="504" alt="Screenshot 2023-04-30 at 18 24 44" src="https://user-images.githubusercontent.com/5582506/235364382-fb5bcd43-eff6-4c76-8a7d-d3b4400621ae.png">

The previous model using both, abstracts and titles.
<img width="495" alt="Screenshot 2023-04-30 at 18 25 31" src="https://user-images.githubusercontent.com/5582506/235364410-11aaa931-3327-4aea-9ce2-f494f2188e1e.png">

The new model (batch size 1, abstracts only)
<img width="501" alt="Screenshot 2023-04-30 at 18 26 51" src="https://user-images.githubusercontent.com/5582506/235364463-543aaa33-76c5-4142-9caa-e3b5d1066953.png">


**After**: the new model + titles + batched 
<img width="505" alt="Screenshot 2023-04-30 at 18 25 04" src="https://user-images.githubusercontent.com/5582506/235364390-a98b601b-fb48-413f-b987-f8fc02b74613.png">

I tied UMAP for it and the results seems less interesting (but didn't experiment much)

<details>
 <summary>UMAP</summary>

<img width="496" alt="Screenshot 2023-04-30 at 18 54 17" src="https://user-images.githubusercontent.com/5582506/235365829-200d7d2c-8ff4-4fb6-8ef3-4bbb5940e0a8.png">

</details>



I also tried using a larger 420Mb model fine-tuned on scientific papers from [SciRepEval](https://api.semanticscholar.org/CorpusID:254018137) - [allenai/specter2](https://huggingface.co/allenai/specter2) \w [proximity adaptor](https://huggingface.co/allenai/specter2_proximity) that takes 1.5min vs 30sec of the above. It can't be switched though the CLI only, as it requires loading an adaptor. 

<details>
 <summary>specter2 TSNE </summary>

<img width="507" alt="Screenshot 2023-04-30 at 18 43 35" src="https://user-images.githubusercontent.com/5582506/235365300-4793170f-b296-405b-a891-59e281df4ce3.png">

</details>

Let me know what you think and which one do you prefer!