### PR TITLE
Add one paper

### DIFF
--- a/_publications/li2024rewriting.markdown
+++ b/_publications/li2024rewriting.markdown
@@ -1,0 +1,11 @@
+---
+layout: publication
+title: Rewriting the Code: A Simple Method for Large Language Model Augmented Code Search
+authors: Haochen Li, Xin Zhou, Zhiqi Shen
+conference: 
+year: 2024
+additional_links:
+   - {name: "ArXiV", url: "https://arxiv.org/abs/2401.04514"}
+tags: ["search", "large language models", "metrics"]
+---
+In code search, the Generation-Augmented Retrieval (GAR) framework, which generates exemplar code snippets to augment queries, has emerged as a promising strategy to address the principal challenge of modality misalignment between code snippets and natural language queries, particularly with the demonstrated code generation capabilities of Large Language Models (LLMs). Nevertheless, our preliminary investigations indicate that the improvements conferred by such an LLM-augmented framework are somewhat constrained. This limitation could potentially be ascribed to the fact that the generated codes, albeit functionally accurate, frequently display a pronounced stylistic deviation from the ground truth code in the codebase. In this paper, we extend the foundational GAR framework and propose a simple yet effective method that additionally Rewrites the Code (ReCo) within the codebase for style normalization. Experimental results demonstrate that ReCo significantly boosts retrieval accuracy across sparse (up to 35.7%), zero-shot dense (up to 27.6%), and fine-tuned dense (up to 23.6%) retrieval settings in diverse search scenarios. To further elucidate the advantages of ReCo and stimulate research in code style normalization, we introduce Code Style Similarity, the first metric tailored to quantify stylistic similarities in code. Notably, our empirical findings reveal the inadequacy of existing metrics in capturing stylistic nuances.


### PR DESCRIPTION

- [x] Files for new publications are in the `_publications` folder.
- [x] The name of each file is `lastnameYEARfirstword.markdown`, _e.g._ `smith2019neural` for a Smith _et al._ paper title "A neural approach to the Universe".
- [x] Consider using tags that already exist. We aim to avoid variations or introducing new ones when possible. This is to help searching across this literature review.
