### PR TITLE
Allow journal key in the publication template

### DIFF
--- a/_layouts/publication.html
+++ b/_layouts/publication.html
@@ -4,7 +4,7 @@ layout: default
 
 <div class="page">
   <h1 class="page-title">{{ page.title }}</h1>
-  <h5>{{ page.authors }}. {{ page.conference }} {{ page.year }}</h5>
+  <h5>{{ page.authors }}. {{ page.conference | default: page.journal }} {{ page.year }}</h5>
   <p>
     {% for additional_link in page.additional_links %}
       [<a href="{{ additional_link.url }}" target="_blank">{{ additional_link.name }}</a>]

--- a/_publications/template
+++ b/_publications/template
@@ -2,11 +2,11 @@
 layout: publication
 title: "Add title here"
 authors: FirstName LastName, FirstName LastName
-conference: Optional
+conference: Optional  # OR journal
 year: 2000
 additional_links:
-   - {name: "ArXiV", url: "https://arxiv.org/abs/xxxx.xxxxxx"}
-   - {name: "Dataset", url: "https://blah/blah"}
+  - {name: "ArXiV", url: "https://arxiv.org/abs/xxxx.xxxxxx"}
+  - {name: "Dataset", url: "https://blah/blah"}
 tags: ["dataset"]
 ---
 Abstract here

--- a/contributing.markdown
+++ b/contributing.markdown
@@ -8,21 +8,22 @@ Contributions of new or missing publications are very welcome. Alternative categ
 
 ### Adding a publication
 To add a publication (new or missing), create a file in the `_publications` folder. The name of the file should follow the structure `lastnameYEARfirstword.markdown` where `lastname` is the last name of the first author and `firstword` is the first non-punctuation word of the work's title. Within each file, follow the structure shown in the other files. Once the file is added, the work will appear in the "All Papers" section.
-<pre>
+
+```yaml
 ---
 layout: publication
 title: The title of the Publication
 authors: F. M. LastName, F. M. LastName, ...
-conference: AbbreviatedNameOfConference
+conference: AbbreviatedNameOfConference  # Or journal: AbbreviatedNameOfJournal
 year: YEAR
 additional_links:
-   - {name: "ArXiV", url: "http://arxiv.org/abs/XXXX.YYYY"}
-   - {name: "website", url: "http://paperwebsite.com"}
-   - {name: "code", url: "https://github.com/path-to/code"}
+  - {name: "ArXiV", url: "http://arxiv.org/abs/XXXX.YYYY"}
+  - {name: "website", url: "http://paperwebsite.com"}
+  - {name: "code", url: "https://github.com/path-to/code"}
 tags: ["tag1", "tag2"]
 ---
 Text of abstract goes here.
-</pre>
+```
 
 The `additional_links` are optional and arbitrary and they will appear on the page referring to this work. Feel free to add as many additional links as needed.
 


### PR DESCRIPTION
Added `journal` key to the publication template. The `conference` key will be displayed when it's available, and if not available, the `journal` key will be used instead. Also, updated the contributing template with a comment regarding the `journal` key.
