### PR TITLE
Update NLTK tokenizer's data

### DIFF
--- a/etc/compute_related.py
+++ b/etc/compute_related.py
@@ -6,7 +6,7 @@ import nltk
 
 nltk.download('stopwords')
 nltk.download('wordnet')
-nltk.download('punkt')
+nltk.download('punkt_tab')
 
 from nltk.corpus import stopwords
 from nltk.stem import WordNetLemmatizer

--- a/etc/compute_topics.py
+++ b/etc/compute_topics.py
@@ -5,7 +5,7 @@ import nltk
 nltk.download('omw-1.4')
 nltk.download('stopwords')
 nltk.download('wordnet')
-nltk.download('punkt')
+nltk.download('punkt_tab')
 
 from nltk.corpus import stopwords
 from nltk.stem import WordNetLemmatizer


### PR DESCRIPTION
The latest version of NLTK has changed its "punkt" resource to ''punkt_tab" to resolve a security vulnerability, and the tokenizer won't work if the old resource is downloaded: https://github.com/nltk/nltk/issues/3293.
This is why the last build of the repository failed.